### PR TITLE
Fix URL handling by preserving trailing slash

### DIFF
--- a/mesh_client/__init__.py
+++ b/mesh_client/__init__.py
@@ -369,7 +369,9 @@ class MeshClient:
             if endpoint_config:
                 url = endpoint_config
 
-        self._url = (url.url if hasattr(url, "url") else url).rstrip("/")
+        self._url = (url.url if hasattr(url, "url") else url)
+        if not self._url.endswith("/"):
+            self._url += "/"
 
         if verify is None and hasattr(url, "verify"):
             verify = url.verify


### PR DESCRIPTION
Hello,  while reviewing the code as part of an ongoing research project, we came across an issue with how URLs are handled when mounting adapters. The current implementation (Line 372 in `mesh_client/__init__.py`)uses:

```python
self._url = (url.url if hasattr(url, "url") else url).rstrip("/")
```

This strips the trailing / from the URL, However, in lines 404–407, `self._url` is passed directly into self._session.mount(...). According to the [Requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#transport-adapters), full hostnames are recommended to be terminated with a slash. Without the slash, certain requests may not be matched by the intended adapter.

We came across this issue while using the project in a research study. Thank you for your time and consideration.
